### PR TITLE
Comment out test tasks in build.grade

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -87,6 +87,6 @@ def generated = 'src/main/generated'
 //	querydsl.extendsFrom compileClasspath
 //
 //}
-	tasks.named('test') {
-	useJUnitPlatform()
-}
+//	tasks.named('test') {
+//	useJUnitPlatform()
+//}


### PR DESCRIPTION
The test tasks execution defined in the build.gradle file has been commented out. 

This is a temporary measure to prevent tests running alongside production code until a suitable testing environment is established.