### PR TITLE
Remove JAR file copy line in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,6 @@ FROM openjdk:17-jdk
 CMD ["./gradlew", "clean", "build"]
 VOLUME /tmp
 ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+#COPY ${JAR_FILE} app.jar
 EXPOSE 8081
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Determined that the copying line for the JAR file in the Dockerfile is unnecessary. 

This line has been commented out to prevent its execution during the build process, which should improve overall efficiency.