### PR TITLE
Update OAuth provider value in OAuthService

### DIFF
--- a/backend/src/main/java/SniffStep/common/config/oauth/OAuthService.java
+++ b/backend/src/main/java/SniffStep/common/config/oauth/OAuthService.java
@@ -39,7 +39,7 @@ public class OAuthService {
         String email = googleUser.getEmail();
         String name = googleUser.getName();
         String providerId = googleUser.getId();
-        String provider = type;
+        String provider = "google";
 
         Member member = authService.registerOrUpdateMember(email, name, providerId, provider);
 


### PR DESCRIPTION
Modified the OAuthService to hard-code the OAuth provider as 'google'. 

This change ensures that the 'provider' field in the 'registerOrUpdateMember' method of the AuthService always receives 'google' as the value.